### PR TITLE
Physics Engine Refactor & Core Optimizations

### DIFF
--- a/Altruist/Core/Framework/Contracts/Router.cs
+++ b/Altruist/Core/Framework/Contracts/Router.cs
@@ -136,7 +136,8 @@ public class ClientSynchronizator
         if (!anyChanges)
             return;
 
-        var syncData = new SyncPacket("server", entity.GetType().Name, changedProperties);
+        var safeCopy = changedProperties.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        var syncData = new SyncPacket("server", entity.GetType().Name, safeCopy);
         await _broadcast.SendAsync(syncData);
     }
 

--- a/Altruist/Core/Framework/Packet.cs
+++ b/Altruist/Core/Framework/Packet.cs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+using System.Collections.Concurrent;
 using System.Text.Json.Serialization;
 using Altruist;
 using Altruist.Networking.Codec.MessagePack;

--- a/Altruist/Core/Framework/Portal/Portal.cs
+++ b/Altruist/Core/Framework/Portal/Portal.cs
@@ -99,7 +99,6 @@ public abstract class Portal<TContext> : IPortal, IConnectionStore where TContex
                 {
                     break;
                 }
-                ;
 
                 var packet = _codec.Decoder.Decode<AltruistPacket>(packetData);
                 if (!await ProcessPacket(packet, packetData, @event, clientId)) break;

--- a/Altruist/Gaming/Main/Core/Player/Player.cs
+++ b/Altruist/Gaming/Main/Core/Player/Player.cs
@@ -126,6 +126,7 @@ public class AltruistPlayerService<TPlayerEntity> : IPlayerService<TPlayerEntity
             if (conn == null || !conn.IsConnected)
             {
                 playersToDelete.Add(player.SysId);
+                player.DetachBody();
             }
         }
 

--- a/Altruist/Gaming/Movement/Core/MovementService.cs
+++ b/Altruist/Gaming/Movement/Core/MovementService.cs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 using Altruist.Physx;
-using FarseerPhysics.Dynamics;
+using Box2DSharp.Dynamics;
 using Microsoft.Extensions.Logging;
 
 namespace Altruist.Gaming.Movement;
@@ -72,8 +72,8 @@ public abstract class BaseMovementService<TPlayerEntity> : IMovementService<TPla
 
     protected void UpdateEntityPosition(TPlayerEntity entity, Body body)
     {
-        entity.Position = [body.Position.X, body.Position.Y];
-        entity.Rotation = body.Rotation;
+        entity.Position = [body.GetPosition().X, body.GetPosition().Y];
+        entity.Rotation = body.GetTransform().Rotation.Angle;
     }
 }
 
@@ -108,7 +108,6 @@ public abstract class ForwardMovementService<T> : BaseMovementService<T> where T
 
         if (result.Moving)
         {
-            entity.CurrentSpeed = result.CurrentSpeed;
             entity.CurrentSpeed = result.CurrentSpeed;
             ClampSpeed(entity);
             _movementPhysx.ApplyMovement(body, result);
@@ -166,13 +165,6 @@ public abstract class EightDirectionVehicleMovementService<TPlayerEntity> : Eigh
     public EightDirectionVehicleMovementService(IPlayerService<TPlayerEntity> playerService, MovementPhysx physx, ICacheProvider cacheProvider, ILoggerFactory loggerFactory)
         : base(playerService, physx, cacheProvider, loggerFactory) { }
 
-
-    // protected override void ApplyRotation(Body body, TPlayerEntity entity, IMovementPacket input)
-    // {
-    //     body.Rotation += entity.RotationSpeed;
-    // }
-
-
     protected override void ApplyMovement(Body body, TPlayerEntity vehicle, IMovementPacket input)
     {
         if (input is not EightDirectionMovementPacket eightDirectionMovementPacket) return;
@@ -198,11 +190,6 @@ public abstract class ForwardSpacehipMovementService<TPlayerEntity> : ForwardMov
     protected ForwardSpacehipMovementService(IPlayerService<TPlayerEntity> playerService, MovementPhysx physx, ICacheProvider cacheProvider, ILoggerFactory loggerFactory) : base(playerService, physx, cacheProvider, loggerFactory)
     {
     }
-
-    // protected override void ApplyRotation(Body body, TPlayerEntity vehicle, IMovementPacket input)
-    // {
-    //     base.ApplyRotation(body, vehicle, input);
-    // }
 
     protected override void ApplyMovement(Body body, TPlayerEntity vehicle, IMovementPacket input)
     {

--- a/Altruist/Physx/Core/Movement/ForwardMovement/ForwardMovement.cs
+++ b/Altruist/Physx/Core/Movement/ForwardMovement/ForwardMovement.cs
@@ -14,8 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-using FarseerPhysics.Dynamics;
-using Microsoft.Xna.Framework;
+using Box2DSharp.Dynamics;
+using Box2DSharp.Common;
+using System.Numerics;
 
 namespace Altruist.Physx;
 
@@ -36,7 +37,8 @@ public class ForwardMovementPhysx : IMovementTypePhysx<ForwardMovementPhysxInput
             );
         }
 
-        Vector2 direction = new Vector2(MathF.Cos(body.Rotation), MathF.Sin(body.Rotation));
+        float angle = body.GetAngle();
+        Vector2 direction = new Vector2(MathF.Cos(angle), MathF.Sin(angle));
         float accelerationFactor = input.Turbo ? 2.0f : 1.0f;
 
         float currentSpeed = input.CurrentSpeed + input.Acceleration * accelerationFactor;
@@ -61,7 +63,8 @@ public class ForwardMovementPhysx : IMovementTypePhysx<ForwardMovementPhysxInput
 
     public virtual MovementPhysxOutput CalculateDeceleration(Body body, ForwardMovementPhysxInput input)
     {
-        Vector2 direction = new Vector2(MathF.Cos(body.Rotation), MathF.Sin(body.Rotation));
+        float angle = body.GetAngle();
+        Vector2 direction = new Vector2(MathF.Cos(angle), MathF.Sin(angle));
 
         float decelerationForce = -input.Deceleration * input.CurrentSpeed;
         Vector2 force = direction * decelerationForce * body.Mass;

--- a/Altruist/Physx/Core/Movement/MovementHelper.cs
+++ b/Altruist/Physx/Core/Movement/MovementHelper.cs
@@ -1,4 +1,5 @@
-using Microsoft.Xna.Framework;
+
+using System.Numerics;
 
 namespace Altruist.Physx;
 

--- a/Altruist/Physx/Core/Movement/MovementInput.cs
+++ b/Altruist/Physx/Core/Movement/MovementInput.cs
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-using FarseerPhysics.Dynamics;
-using Microsoft.Xna.Framework;
+using System.Numerics;
+using Box2DSharp.Dynamics;
 
 namespace Altruist.Physx;
 
@@ -24,13 +24,19 @@ public record MovementPhysxOutput
     public float CurrentSpeed { get; set; }
     public float RotationSpeed { get; set; }
     public bool Moving { get; set; }
-    // public Vector2 Position { get; set; }
 
     public Vector2 Velocity { get; set; }
 
     public Vector2 Force { get; set; }
 
-    public MovementPhysxOutput(float currentSpeed, float rotationSpeed, bool moving, Vector2 velocity, Vector2 force) => (CurrentSpeed, RotationSpeed, Moving, Velocity, Force) = (currentSpeed, rotationSpeed, moving, velocity, force);
+    public MovementPhysxOutput(float currentSpeed, float rotationSpeed, bool moving, Vector2 velocity, Vector2 force)
+    {
+        CurrentSpeed = currentSpeed;
+        RotationSpeed = rotationSpeed;
+        Moving = moving;
+        Velocity = velocity;
+        Force = force;
+    }
 }
 
 public interface IMovementTypePhysx<TInput> where TInput : MovementPhysxInput

--- a/Altruist/Physx/Core/Movement/MovementPhysx.cs
+++ b/Altruist/Physx/Core/Movement/MovementPhysx.cs
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-using FarseerPhysics.Dynamics;
-using Microsoft.Xna.Framework;
+using System.Numerics;
+using Box2DSharp.Dynamics;
 
 namespace Altruist.Physx;
 
@@ -24,6 +24,8 @@ public class VectorConstants
     public static readonly Vector2 ZeroVector = Vector2.Zero;
     public static readonly Vector2 LeftDirection = new Vector2(-1, 0);
     public static readonly Vector2 RightDirection = new Vector2(1, 0);
+    public static readonly Vector2 UpDirection = new Vector2(0, 1);
+    public static readonly Vector2 DownDirection = new Vector2(0, -1);
 }
 
 public class MovementPhysx
@@ -39,12 +41,17 @@ public class MovementPhysx
 
     public void ApplyMovement(Body body, MovementPhysxOutput input)
     {
-        body.LinearVelocity = input.Velocity;
-        body.Rotation += input.RotationSpeed;
-
-        if (input.Force != Vector2.Zero)
+        body.SetLinearVelocity(input.Velocity);
+        if (input.RotationSpeed != 0)
         {
-            body.ApplyForce(input.Force);
+            var currentPosition = body.GetPosition();
+            var currentAngle = body.GetAngle();
+            body.SetTransform(currentPosition, currentAngle + input.RotationSpeed);
+        }
+
+        if (input.Force.X != 0 || input.Force.Y != 0)
+        {
+            body.ApplyForce(input.Force, body.GetWorldCenter(), true);
         }
     }
 }

--- a/Altruist/Physx/Physx.csproj
+++ b/Altruist/Physx/Physx.csproj
@@ -15,11 +15,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath=""/>
+    <None Include="README.md" Pack="true" PackagePath="" />
   </ItemGroup>
   
-  <ItemGroup >
-    <PackageReference Include="FarseerPhysics" Version="3.5.0" />
+  <ItemGroup>
+    <PackageReference Include="Box2DSharp" Version="0.6.0" />
   </ItemGroup>
 
 </Project>

--- a/Examples/SimpleProject/Program.cs
+++ b/Examples/SimpleProject/Program.cs
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+using System.Numerics;
 using Altruist;
 using Altruist.Gaming;
 using Altruist.Gaming.Engine;
 using Altruist.Web;
-using Microsoft.Xna.Framework;
+
 using Portals;
 
 AltruistBuilder.Create(args)
@@ -29,7 +30,6 @@ AltruistBuilder.Create(args)
     setup.MapPortal<SimpleGamePortal>("/game").MapPortal<SimpleMovementPortal>("/game"))
     .WebApp()
     .StartServer();
-
 
 public class MainWorldIndex : WorldIndex
 {

--- a/Tests/Altruist/Framework/Networking.cs
+++ b/Tests/Altruist/Framework/Networking.cs
@@ -1,0 +1,56 @@
+namespace Altruist.Networking;
+
+public class BaseEntity
+{
+    [Synced(0)]
+    public int A { get; set; }
+
+    [Synced(1, SyncAlways: true)]
+    public int B { get; set; }
+}
+
+public class DerivedEntity : BaseEntity
+{
+    [Synced(0)]
+    public int C { get; set; }
+
+    [Synced(1)]
+    public int D { get; set; }
+}
+
+public class SyncMetadataHelperTests
+{
+    [Fact]
+    public void Metadata_ShouldIncludeBaseAndDerivedProperties_WithCorrectBitIndices()
+    {
+        var (props, count) = SyncMetadataHelper.GetSyncMetadata(typeof(DerivedEntity));
+
+        Assert.Equal(4, count);
+
+        var expected = new Dictionary<string, int>
+        {
+            ["A"] = 0,
+            ["B"] = 1,
+            ["C"] = 2, // base max index = 1 → +1 = 2
+            ["D"] = 3  // BitIndex 1 + baseMax 1 + 1 = 3
+        };
+
+        foreach (var p in props)
+        {
+            Assert.True(expected.ContainsKey(p.Name), $"Unexpected property: {p.Name}");
+            Assert.Equal(expected[p.Name], p.BitIndex);
+        }
+
+        Assert.True(props.First(p => p.Name == "B").SyncAlways);
+    }
+
+    [Fact]
+    public void Metadata_CachesResultAcrossCalls()
+    {
+        var (props1, _) = SyncMetadataHelper.GetSyncMetadata(typeof(DerivedEntity));
+        var (props2, _) = SyncMetadataHelper.GetSyncMetadata(typeof(DerivedEntity));
+
+        // Should return same instance due to caching
+        Assert.Same(props1, props2);
+    }
+}

--- a/Tests/Altruist/Gaming/Movement/BaseMovementServiceTests.cs
+++ b/Tests/Altruist/Gaming/Movement/BaseMovementServiceTests.cs
@@ -1,8 +1,8 @@
 
+using System.Numerics;
 using Altruist.Physx;
-using FarseerPhysics.Dynamics;
+using Box2DSharp.Dynamics;
 using Microsoft.Extensions.Logging;
-using Microsoft.Xna.Framework;
 using Moq;
 
 namespace Altruist.Gaming.Movement;

--- a/Tests/Altruist/Gaming/Movement/SpaceshipMovementServiceTest.cs
+++ b/Tests/Altruist/Gaming/Movement/SpaceshipMovementServiceTest.cs
@@ -1,7 +1,7 @@
+using System.Numerics;
 using Altruist.Physx;
-using FarseerPhysics.Dynamics;
+using Box2DSharp.Dynamics;
 using Microsoft.Extensions.Logging;
-using Microsoft.Xna.Framework;
 using Moq;
 
 namespace Altruist.Gaming.Movement;

--- a/Tests/Altruist/Gaming/World/WorldPartitoningTests.cs
+++ b/Tests/Altruist/Gaming/World/WorldPartitoningTests.cs
@@ -16,8 +16,8 @@ limitations under the License.
 
 namespace Altruist.Gaming;
 
+using System.Numerics;
 using FluentAssertions;
-using Microsoft.Xna.Framework;
 using Xunit;
 
 public class TestWorldIndex : WorldIndex


### PR DESCRIPTION
# Summary
This pull request introduces several important structural and performance-related improvements across the engine, including:

## Physics Engine Migration
Migrated from Farseer to Box2DSharp
- Replaced Farseer-specific bodies, joints, and world logic
- Adjusted body creation, force application, and world stepping to use Box2DSharp conventions (e.g. half-width boxes, SetLinearVelocity)
- Updated existing movement and collision logic accordingly

## Engine Architecture Improvements
Separated the main engine loop from the physics loop

- Main engine now runs on a dedicated thread, handling scheduling and task dispatching
- Physics simulation executes on a separate thread with independent tick rate
- Reduced contention and improved parallelization

## Optimization Improvements
- Replaced per-frame Task.Run() dispatches with dedicated loop threads
- Pooled memory allocations (e.g. bitmask arrays) using ArrayPool<T>
- Avoided unnecessary GC pressure by:
- - Reusing cursors and collections
- - Avoiding temporary Dictionary allocations
Added low-level thread naming and priority tuning for clearer diagnostics and profiling

## Test & Validation
- Added Box2DSharp-backed test setup for physics-related unit tests
- Maintained backward-compatible behavior for physics-driven movement

These changes lay the foundation for:
- Better runtime performance under load
- Easier support for multiple physics "worlds" in parallel
